### PR TITLE
require('uuid/v4') requires uuid 3.0.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "mkdirp": "*",
     "colors": "*",
     "express": "*",
-    "phantomjs-prebuilt": "2.1.13",    
+    "phantomjs-prebuilt": "2.1.13",
     "body-parser": "*",
     "prompt": "*",
     "request": "*",
     "express-form-data": "*",
     "cors": "*",
-    "uuid": "*"
+    "uuid": ">=3.0.1"
   },
   "engines": {
     "node": ">=5.10.0"


### PR DESCRIPTION
The `require('uuid/v4')` call absolutely requires node-uuid 3.0.1+. Calling the API in that manner was introduced in 3.0.1. Because the dependency in node-export-server is defined as `"uuid": "*"`, that require will fail when this module is installed along side ANY other module that has a stricter uuid dependency that resolves lower than 3.0.1 (as it does in my case).

A simple example would be dependencies that look like this:

```
"dependencies": {
  "highcharts-export-server": "*",
  "uuid": "^1.4.0"
}
```

An npm/yarn install will install node-uuid 1.4.X, and then highcharts-export-server will throw the error `Cannot find module 'uuid/v4'`.