### PR TITLE
Bugfix missing params in 'post' exported function

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -368,7 +368,7 @@ module.exports = {
         app.get(path, fn);
     },
 
-    post: function () {
+    post: function (path, fn) {
         app.post(path, fn);
     },
 


### PR DESCRIPTION
Bugfix missing params in 'post' exported function