### PR TITLE
Allow customization of timeoutThreshold in phantompool.js - #171

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ The export server can also be used as a node module to simplify integrations:
     * `initialWorkers` (default 5) - initial worker process count
     * `workLimit` (default 50) - how many task can be performed by a worker process before it's automatically restarted
     * `queueSize` (default 5) - how many request can be stored in overflow count when there are not enough workers to handle all requests
+    * `timeoutThreshold` (default 3500) - the maximum allowed time for each export job execution, in milliseconds. If a worker has been executing a job for longer than this period, it will be restarted
   * `killPool()`: kill the phantom processes
 
 ## Using Ajax in Injected Resources

--- a/lib/phantompool.js
+++ b/lib/phantompool.js
@@ -296,7 +296,7 @@ function init(config) {
 
     settings = {
         queueSize: config.queueSize || 5,
-        timeoutThreshold: 3500,
+        timeoutThreshold: config.timeoutThreshold || 3500,
         maxWorkers: config.maxWorkers || 8,
         initialWorkers: config.initialWorkers || config.maxWorkers || 8,
         worker: config.worker || __dirname + '/../phantom/worker.js',


### PR DESCRIPTION
As described in https://github.com/highcharts/node-export-server/issues/171, the default 3.5s `timeoutThreshold` in `lib/phantompool.js` is too restrictive for line/time series charts with large data sets (100,000+ points, 30+ series).

Proposed solution allows the user to configure this parameter when initializing the worker pool. I was not sure if this applies to the CLI and the HTTP server modes and can update the PR if need to include those as well.