### PR TITLE
Remove x-powered-by header

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -82,6 +82,7 @@ function doCallbacks(which, req, res, data, id, uniqueid, type) {
     return res;
 }
 
+app.disable('x-powered-by');
 app.use(cors());
 app.use(formData.parse());
 app.use(bodyParser.urlencoded({ extended: true, limit: '50mb' }));


### PR DESCRIPTION
It's better to remove Express.js x-powered-by header for security concerns.

https://stackoverflow.com/questions/10717685/how-to-remove-x-powered-by-in-expressjs