### PR TITLE
Fix: cdnAdditional scripts breaking during build because of special characters

### DIFF
--- a/build.js
+++ b/build.js
@@ -266,7 +266,7 @@ function embed(version, scripts, out, fn, optionals) {
         fs.writeFile(
             __dirname + '/phantom/' + out + '.html',
             template
-                .replace('"{{highcharts}}";', scriptBody)
+                .replace('"{{highcharts}}";', () => scriptBody)
                 .replace('<div style="padding:5px;">', '<div style="padding:5px;display:none;">')
                 .replace('{{additionalScripts}}', additionalScripts)
                 ,


### PR DESCRIPTION
If `cdnAdditional` resource scripts contain characters such as `$$`, `$&`, current replace function will  consider them as special, and break the script.

Using a function instead of plain string during replacement will safely handle these characters.

All details are here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter