### PR TITLE
using absolute path instead of realtive path.

### DIFF
--- a/lib/phantompool.js
+++ b/lib/phantompool.js
@@ -124,7 +124,7 @@ function spawnWorker(processQueueAfterCreation) {
         }
     }
 
-    worker.process = phantomjs.exec(settings.worker, (__dirname + '/../'));
+    worker.process = phantomjs.exec(settings.worker, path.join(path.resolve(__dirname, './../'), '/'));
     worker.process.stdin.setEncoding('utf-8');
     worker.process.stdout.setEncoding('utf-8');
 


### PR DESCRIPTION
fix for https://github.com/highcharts/node-export-server/issues/224. I've mentioned the problem in greater detail in the issue.