### PR TITLE
Forced all packages to use exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   "dependencies": {
     "async": "2.1.4",
     "body-parser": "1.16.0",
-    "colors": "*",
+    "colors": "1.3.3",
     "cors": "2.8.1",
     "express": "4.16.0",
     "express-form-data": "2.0.0",
     "express-rate-limit": "2.6.0",
     "mkdirp": "0.5.1",
     "phantomjs-prebuilt": "2.1.14",
-    "prompt": "*",
-    "request": "*",
-    "uuid": ">=3.0.1"
+    "prompt": "1.0.0",
+    "request": "2.88.0",
+    "uuid": "3.0.1"
   },
   "engines": {
     "node": ">=6.4.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "4.16.0",
     "express-form-data": "2.0.0",
     "express-rate-limit": "2.6.0",
-    "mkdirp": "*",
+    "mkdirp": "0.5.1",
     "phantomjs-prebuilt": "2.1.14",
     "prompt": "*",
     "request": "*",


### PR DESCRIPTION
A new version of mkdirp was released which breaks node-export-server. (https://www.npmjs.com/package/mkdirp). Instead of using a * for the version, this project should use a version which is known to work.