### PR TITLE
Fixed #234, lollipop and dumbbell modules added to build

### DIFF
--- a/build.js
+++ b/build.js
@@ -60,7 +60,9 @@ const cdnScriptsOptional = {
   '{{version}}/modules/timeline.js': 1,
   '{{version}}/modules/pareto.js': 1,
   '{{version}}/modules/coloraxis.js': 1,
-  '{{version}}/modules/venn.js': 1
+  '{{version}}/modules/venn.js': 1,
+  "{{version}}/modules/dumbbell.js": 1,
+  '{{version}}/modules/lollipop.js': 1
 };
 
 // The scripts here will appear as user prompts


### PR DESCRIPTION
Added support for lollipop charts (and dumbbell charts, because lollipop charts depend on those). Fixes #234 