### PR TITLE
Allow configuration of worker timeout threshold via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ ln -s `which nodejs` /usr/bin/node
   * `--workers`: Number of workers to spawn
   * `--workLimit`: the pieces of work that can be performed before restarting a phantom process
   * `--queueSize`: how many request can be stored in overflow count when there are not enough
+  * `--workTimeout`: timeout for workers to render a chart (milliseconds)
   * `--listenToProcessExits`: set to 0 to skip attaching process.exit handlers. Note that disabling this may cause zombie processes!
   * `--globalOptions`: A JSON string with options to be passed to Highcharts.setOptions
   * `--allowCodeExecution`: Set to 1 to allow execution of arbitrary code when exporting. Defaults to `0`, and is required for `callback`, `resources`, and `customCode` export settings. *Turning this on is not recommended unless running on a sandboxed server without access to the general internet, or if running well-defined exports using the CLI*

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -151,6 +151,11 @@ addOption(
   "<number>: the pieces of work that can be performed before restarting a phantom process"
 );
 addOption("queueSize", 5, "<number>: the size of the request overfow queue");
+addOption(
+  "workTimeout",
+  3500,
+  "<number>: Timeout for workers to render a chart (milliseconds)"
+)
 
 addOption(
   "logDest",
@@ -271,7 +276,8 @@ if (options.enableServer || (options.host && options.host.length)) {
     initialWorkers: options.workers || 0,
     maxWorkers: options.workers || 4,
     workLimit: options.workLimit,
-    queueSize: options.queueSize
+    queueSize: options.queueSize,
+    timeoutThreshold: +options.workTimeout
   });
 
   if (


### PR DESCRIPTION
Implements #175

Different to #176, naming is more in-line with worker options to avoid confusion. Also updates `README`