### PR TITLE
Disable-async-option

### DIFF
--- a/build.js
+++ b/build.js
@@ -294,19 +294,26 @@ function embed(version, scripts, out, fn, optionals) {
 
         console.log('Creating export template', out + '..');
 
+        // Insert scriptbody without using regex.
+        const handlebar = '"{{highcharts}}"';
+        const hcIndex = template.indexOf(handlebar);
+        const output = [
+          template.slice(0, hcIndex),
+          scriptBody,
+          template.slice(hcIndex + handlebar.length)
+        ].join('')
+          .replace('<div style="padding:5px;">', '<div style="padding:5px;display:none;">')
+          .replace('{{additionalScripts}}', additionalScripts)
+
         fs.writeFile(
-            __dirname + '/phantom/' + out + '.html',
-            template
-                .replace('"{{highcharts}}";', scriptBody)
-                .replace('<div style="padding:5px;">', '<div style="padding:5px;display:none;">')
-                .replace('{{additionalScripts}}', additionalScripts)
-                ,
-            function (err) {
-                if (err) return console.log('Error creating template:', err);
-                if (fn) fn();
-            }
+          __dirname + '/phantom/' + out + '.html',
+          output,
+          function (err) {
+            if (err) return console.log('Error creating template:', err);
+            if (fn) fn();
+          }
         );
-    });
+      });
 }
 
 function endMsg() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,6 +56,7 @@ const mimeReverse = {
 
 var rc = 0,
   allowCodeExecution = false,
+  allowAsync = true,
   beforeRequest = [],
   afterRequest = [],
   tmpDir = false,
@@ -215,6 +216,13 @@ function handlePost(req, res) {
       );
   }
 
+  // Disable async option by config
+  if (req.body.async && !allowAsync) {
+    return res
+      .status(400)
+      .send('The async option has been disabled.\nSee https://www.highcharts.com/docs/export-module/deprecated-async-option for alternatives');
+  }
+
   cres = doCallbacks(beforeRequest, req, res, req.body, id, uniqueid, type);
   if (cres !== true) {
     //Block request
@@ -226,6 +234,7 @@ function handlePost(req, res) {
   req.on("close", function () {
     connectionAborted = true;
   });
+
 
   chart(
     {
@@ -364,13 +373,15 @@ module.exports = {
     sslOnly,
     newTmpDir,
     host,
-    allowCodeEval
+    allowCodeEval,
+    allowAsyncOption = true
   ) {
     var httpServer = http.createServer(app),
       httpsServer;
 
     tmpDir = newTmpDir || tmpDir;
     allowCodeExecution = allowCodeEval;
+    allowAsync = allowAsyncOption;
 
     function errorHandler(err, socket) {
       log(1, "socket error:", err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highcharts-export-server",
-  "version": "2.0.30",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This adds an option to disable the `async` option when starting the export server as a Node module.
Also fixed an issue where an `$&` was replaced with `{{highcharts}}` when fetching the annotations module.