### PR TITLE
fix: issue that comes up with node versions > 16

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -231,10 +231,10 @@ function handlePost(req, res) {
 
   log(4, "got incoming HTTP request", uniqueid);
 
-  req.on("close", function () {
+  res.on("close", function () {
+    // Will also be called after the response finished but at that point we don't care about this value anymore.
     connectionAborted = true;
   });
-
 
   chart(
     {


### PR DESCRIPTION
Fix an issue where the highcharts export server would think that the client closed the connection prematurely when running on node version >= 16.

Based my fix on [this discussion](https://stackoverflow.com/questions/7062885/expressjs-how-to-know-when-a-request-has-finished) and searching the [node documentation](https://nodejs.org/docs/latest-v16.x/api/http2.html) for alternative events that can be used to determine aborted connections. I came up with checking the response for being closed. This will either be fired when the response is done when it doesn't matter anymore or when the client lost connection before receiving the result.