### PR TITLE
54/custom-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ _Available options:_
 - `--allowForceInject`: Allow injecting code directly. Has no effect when running as a server. (defaults to `false`)
 - `--resources`: An additional resource in a form of stringified JSON. It can contains files, js and css sections. (defaults to `false`)
 - `--callback`: A JavaScript file with a function to run on construction. (defaults to `false`)
+- `--customCode`: Custom code to be called before chart initialization. Can be a function, a code that will be wrapped within a function or a filename with the js extension.
 - `--loadConfig`: A file that contains a pre-defined config to use. (defaults to `false`)
 - `--createConfig`: Allows to set options through a prompt and save in a provided config file. (defaults to `false`)
 - `--enableServer`: If set to true, starts a server on 0.0.0.0. (defaults to `false`)
@@ -238,6 +239,7 @@ The format, with its default values are as follows:
     "allowFileResources": true,
     "allowForceInject": false,
     "callback": false,
+    "customCode": false,
     "resources": false,
     "loadConfig": false,
     "createConfig": false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Version 2.1.0 has a couple of breaking changes:
 - The following options are now disabled by default:
   - `callback`
   - `resources`
-  <!-- - `customCode` -->
+  - `customCode`
 
 Disabled options can be enabled by adding the `--allowCodeExecution` flag when
 starting the server/CLI. Using this flag is not recommended, and should not be
@@ -440,8 +440,8 @@ The server accepts the following arguments in a POST body:
 - `noDownload`: Bool, set to true to not send attachment headers on the response.
 <!-- - `asyncRendering`: Wait for the included scripts to call `highexp.done()` before rendering the chart. -->
 - `globalOptions`: A JSON object with options to be passed to `Highcharts.setOptions`.
-<!-- - `dataOptions`: Passed to `Highcharts.data(..)`
-- `customCode`: When `dataOptions` is supplied, this is a function to be called with the after applying the data options. Its only argument is the complete options object which will be passed to the Highcharts constructor on return. -->
+<!-- - `dataOptions`: Passed to `Highcharts.data(..)` -->
+- `customCode`: Custom code to be called before chart initialization. Can be a function, a code that will be wrapped within a function or a filename with the js extension.
 
 Note that the `b64` option overrides the `async` option.
 

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -18,7 +18,7 @@ const path = require('path');
 
 const pool = require('./pool.js');
 const { log } = require('./logger');
-const { fixType, isCorrectJSON } = require('./utils.js');
+const { fixType, isCorrectJSON, wrapAround } = require('./utils.js');
 
 let allowCodeExecution = false;
 
@@ -29,8 +29,12 @@ const doExport = (options, chartJson, endCallback, svg) => {
   // of callback, resources, and custom code. Additionally, the worker will
   // refuse to run arbitrary JavaScript.
   if (!allowCodeExecution) {
-    if (customCodeOptions.callback || customCodeOptions.resources) {
-      const message = `callback and resources have been disabled for this server.
+    if (
+      customCodeOptions.callback ||
+      customCodeOptions.resources ||
+      customCodeOptions.customCode
+    ) {
+      const message = `callback, resources and customCode have been disabled for this server.
 
       If you require these options, consider running your own instance of the export server, which can be found here: https://github.com/highcharts/node-export-server.
 
@@ -54,6 +58,7 @@ const doExport = (options, chartJson, endCallback, svg) => {
     // Reset all additional custom code
     customCodeOptions.callback = false;
     customCodeOptions.resources = false;
+    customCodeOptions.customCode = false;
   }
 
   // Clean properties to keep it lean and mean
@@ -115,6 +120,9 @@ const doExport = (options, chartJson, endCallback, svg) => {
       log(1, `[chart] - The ${optionsName} not found.`);
     }
   });
+
+  // Prepare customCode
+  customCodeOptions.customCode = wrapAround(customCodeOptions.customCode);
 
   const executeExport = () => {
     // Post the work to the pool

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -159,14 +159,14 @@ const defaultConfig = {
     },
     height: {
       envLink: 'EXPORT_DEFAULT_HEIGHT',
-      value: 1200,
+      value: 400,
       type: 'number',
       description:
         'The height of the exported chart. Overrides the option in the chart settings.'
     },
     width: {
       envLink: 'EXPORT_DEFAULT_WIDTH',
-      value: 800,
+      value: 600,
       type: 'number',
       description:
         'The width of the exported chart. Overrides the option in the chart settings.'
@@ -199,7 +199,7 @@ const defaultConfig = {
   customCode: {
     allowCodeExecution: {
       envLink: 'HIGHCHARTS_ALLOW_CODE_EXECUTION',
-      value: false,
+      value: true,
       type: 'boolean',
       description:
         'If set to true, allow for the execution of arbitrary code when exporting.'
@@ -218,6 +218,12 @@ const defaultConfig = {
       description:
         'Allow injecting code directly. Has no effect when running as a server.'
     },
+    customCode: {
+      value: false,
+      type: 'string',
+      description:
+        'A function to be called before chart initialization. Can be a filename with the js extension.'
+    },
     callback: {
       value: false,
       type: 'string',
@@ -227,7 +233,7 @@ const defaultConfig = {
       value: false,
       type: 'string',
       description:
-        'An additional resource in a form of stringified JSON. It can contains files, js and css sections.'
+        'An additional resource in a form of stringified JSON. It can contain files, js and css sections.'
     },
     loadConfig: {
       value: false,
@@ -721,6 +727,7 @@ const nestedArgs = {
   allowFileResources: 'customCode.allowFileResources',
   allowForceInject: 'customCode.allowForceInject',
   resources: 'customCode.resources',
+  customCode: 'customCode.customCode',
   callback: 'customCode.callback',
   loadConfig: 'customCode.loadConfig',
   createConfig: 'customCode.createConfig',

--- a/lib/server/routes/export.js
+++ b/lib/server/routes/export.js
@@ -154,7 +154,8 @@ const exportHandler = (request, response) => {
     customCode: {
       allowFileResources: false,
       resources: isCorrectJSON(body.resources, true),
-      callback: body.callback
+      callback: body.callback,
+      customCode: body.customCode
     }
   };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,6 +246,30 @@ const printUsage = (defaultConfig) => {
 const toBoolean = (item) =>
   ['0', 'false', 'NaN', 'null', 'undefined'].includes(item) ? false : !!item;
 
+/** If necessary, places a custom code inside a function
+ * @export utils
+ * @param customCode {any} The customCode
+ */
+const wrapAround = (customCode) => {
+  if (customCode && typeof customCode === 'string') {
+    customCode = customCode.trim();
+
+    if (customCode.endsWith('.js')) {
+      return wrapAround(readFileSync(path.join(__basedir, customCode), 'utf8'));
+    } else if (
+      !(
+        customCode.startsWith('function ()') ||
+        customCode.startsWith('()=>') ||
+        customCode.startsWith('() =>')
+      )
+    ) {
+      return `() => { ${customCode} }`;
+    }
+
+    return customCode.replace(/;$/, '');
+  }
+};
+
 module.exports = {
   fixType,
   handleResources,
@@ -255,5 +279,6 @@ module.exports = {
   pairArgumentValue,
   printLogo,
   printUsage,
-  toBoolean
+  toBoolean,
+  wrapAround
 };

--- a/templates/json_export/json_export.js
+++ b/templates/json_export/json_export.js
@@ -41,6 +41,7 @@ module.exports = (chartOptions, options, hcSources) => `
     </div>
 
     <script>
+      (${options.customCode.customCode})();
       ${jsTemplate(chartOptions, options)}
     </script>
   </body>


### PR DESCRIPTION
Reintroduced the customCode option that allows to call a function with such a code just before chart initialization, touch #54.