### PR TITLE
enhancement/puppeteer-node-module

### DIFF
--- a/lib/chart.js
+++ b/lib/chart.js
@@ -26,6 +26,9 @@ import {
   toBoolean,
   wrapAround
 } from './utils.js';
+import { initDefaultOptions } from './config.js';
+import { mergeConfigOptions } from './utils.js';
+import { defaultConfig } from './schemas/config.js';
 
 let allowCodeExecution = false;
 
@@ -317,6 +320,21 @@ export default {
   startExport: async (options, endCallback) => {
     // Starting exporting process message
     log(4, '[chart] Starting exporting process.');
+
+    // Initialize the options with default options
+    const initialOptions = { ...{ ...options } };
+    if (options.svg) {
+      options = initDefaultOptions(defaultConfig);
+      options.export.type = initialOptions.type || initialOptions.export.type;
+      options.export.scale = initialOptions.scale || initialOptions.export.scale;
+      options.payload = {
+        svg: initialOptions.svg
+      };
+    } else {
+      options = mergeConfigOptions(initDefaultOptions(defaultConfig), options, ['options', 'resources', 'globalOptions', 'themeOptions']);
+    }
+
+    options.export.outfile = options.export?.outfile || `chart.${options.export?.type || '.png'}`;
 
     // Get the export options
     const exportOptions = options.export;

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -26,9 +26,7 @@ import {
   toBoolean,
   wrapAround
 } from './utils.js';
-import { initExportSettings, initDefaultOptions } from './config.js';
-import { mergeConfigOptions } from './utils.js';
-import { defaultConfig } from './schemas/config.js';
+import { initExportSettings } from './config.js';
 
 let allowCodeExecution = false;
 

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -26,7 +26,7 @@ import {
   toBoolean,
   wrapAround
 } from './utils.js';
-import { initDefaultOptions } from './config.js';
+import { initExportSettings, initDefaultOptions } from './config.js';
 import { mergeConfigOptions } from './utils.js';
 import { defaultConfig } from './schemas/config.js';
 
@@ -313,28 +313,16 @@ const exportAsString = (stringToExport, options, endCallback) => {
 /**
  * Starts an exporting process
  *
- * @param {object} options - All options object.
+ * @param {object} exportSettings - All options object.
  * @param {function} endCallback - The function to call when exporting is done.
  */
 export default {
-  startExport: async (options, endCallback) => {
+  startExport: async (exportSettings, endCallback) => {
     // Starting exporting process message
     log(4, '[chart] Starting exporting process.');
 
-    // Initialize the options with default options
-    const initialOptions = { ...{ ...options } };
-    if (options.svg) {
-      options = initDefaultOptions(defaultConfig);
-      options.export.type = initialOptions.type || initialOptions.export.type;
-      options.export.scale = initialOptions.scale || initialOptions.export.scale;
-      options.payload = {
-        svg: initialOptions.svg
-      };
-    } else {
-      options = mergeConfigOptions(initDefaultOptions(defaultConfig), options, ['options', 'resources', 'globalOptions', 'themeOptions']);
-    }
-
-    options.export.outfile = options.export?.outfile || `chart.${options.export?.type || '.png'}`;
+    // Initialize options
+    const options = initExportSettings(exportSettings);
 
     // Get the export options
     const exportOptions = options.export;

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,7 @@ import prompts from 'prompts';
 import { log } from './logger.js';
 import { mergeConfigOptions } from './utils.js';
 
-import { promptsConfig } from './schemas/config.js';
+import { defaultConfig, promptsConfig } from './schemas/config.js';
 
 /**
  * Loads the configuration from JSON file.
@@ -183,8 +183,36 @@ export const initDefaultOptions = (items) => {
   return options;
 };
 
+/**
+ * Inits default options for startExport method.
+ * @param {any} userOptions - User options for exporting.
+ * @return {object} - User options merged with default options.
+ */
+export const initExportSettings = (userOptions) => {
+  let options = {};
+
+  if (userOptions.svg) {
+    options = initDefaultOptions(defaultConfig);
+    options.export.type = userOptions.type || userOptions.export.type;
+    options.export.scale = userOptions.scale || userOptions.export.scale;
+    options.payload = {
+      svg: userOptions.svg
+    };
+  } else {
+    options = mergeConfigOptions(
+      initDefaultOptions(defaultConfig),
+      userOptions,
+      ['options', 'resources', 'globalOptions', 'themeOptions']
+    );
+  }
+
+  options.export.outfile = options.export?.outfile || `chart.${options.export?.type || '.png'}`;
+  return options;
+}
+
 export default {
   loadConfigFile,
   manualConfiguration,
-  initDefaultOptions
+  initDefaultOptions,
+  initExportSettings
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,8 +39,10 @@ export default {
       ['options', 'globalOptions', 'themeOptions', 'resources']
     ),
   initPool: async (options = {}) => {
+    const defaultOptions = initDefaultOptions(defaultConfig);
+
     // Load an optional config file
-    options = await loadConfigFile(options);
+    options = await loadConfigFile(mergeConfigOptions(defaultOptions, options));
 
     // Set the allowCodeExecution per export module scope
     chart.setAllowCodeExecution(

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -12,18 +12,17 @@ See LICENSE file in root for details.
 
 *******************************************************************************/
 
-import { v4 as uuid } from "uuid";
-import { createPool } from "generic-pool";
+import { v4 as uuid } from 'uuid';
+import { createPool } from 'generic-pool';
 import {
   get,
   close,
   newPage as browserNewPage,
-  create as createBrowser,
-} from "./browser.js";
-import { log } from "./logger.js";
-import { expBackoff } from "./utils.js";
+  create as createBrowser
+} from './browser.js';
+import { log } from './logger.js';
 
-import puppeteerExport from "./export.js";
+import puppeteerExport from './export.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -66,7 +65,7 @@ const factory = {
         page = await browserNewPage();
         log(3, `[pool] Successfully created a worker ${id}.`);
       } else {
-        log(0, "[pool] unable to get browser");
+        log(0, '[pool] unable to get browser');
       }
     } catch (error) {
       browserInstance = false;
@@ -112,7 +111,7 @@ export const init = async (config) => {
   try {
     await createBrowser(puppeteerArgs);
   } catch (e) {
-    log(0, "[pool|browser]", e);
+    log(0, '[pool|browser]', e);
   }
 
   // For the module scope usage
@@ -120,14 +119,14 @@ export const init = async (config) => {
 
   log(
     3,
-    "[pool] Initializing pool:",
+    '[pool] Initializing pool:',
     `min ${poolConfig.initialWorkers}, max ${poolConfig.maxWorkers}.`
   );
 
   if (pool) {
     return log(
       4,
-      "[pool] Already initialized, please kill it before creating a new one."
+      '[pool] Already initialized, please kill it before creating a new one.'
     );
   }
 
@@ -169,27 +168,27 @@ export const init = async (config) => {
  * Attaches process' exit listeners.
  */
 export function attachProcessExitListeners() {
-  log(4, "[pool] Attaching exit listeners to the process.");
+  log(4, '[pool] Attaching exit listeners to the process.');
 
   // Kill all pool resources on exit
-  process.on("exit", async () => {
+  process.on('exit', async () => {
     await killAll();
   });
 
   // Handler for the SIGINT
-  process.on("SIGINT", (name, code) => {
+  process.on('SIGINT', (name, code) => {
     log(4, `The ${name} event with code: ${code}.`);
     process.exit(1);
   });
 
   // Handler for the SIGTERM
-  process.on("SIGTERM", (name, code) => {
+  process.on('SIGTERM', (name, code) => {
     log(4, `The ${name} event with code: ${code}.`);
     process.exit(1);
   });
 
   // Handler for the uncaughtException
-  process.on("uncaughtException", async (error, name) => {
+  process.on('uncaughtException', async (error, name) => {
     log(4, `The ${name} error, message: ${error.message}.`);
   });
 }
@@ -198,7 +197,7 @@ export function attachProcessExitListeners() {
  * Kills the pool and flush all the browser instances.
  */
 export async function killAll() {
-  log(3, "[pool] Killing all workers.");
+  log(3, '[pool] Killing all workers.');
 
   // Close browser instance
   await close();
@@ -210,7 +209,7 @@ export async function killAll() {
 
   // Start drainging pool and eventually clear it
   return pool.drain().then(() => {
-    log(4, "[pool] Started draining process.");
+    log(4, '[pool] Started draining process.');
     pool.clear();
   });
 }
@@ -222,11 +221,11 @@ export async function killAll() {
  * @param {object} options - All options object.
  */
 export const postWork = async (chart, options) => {
-  log(3, "[pool] Work received, starting to process.");
+  log(3, '[pool] Work received, starting to process.');
 
   if (!pool) {
-    log(1, "[pool] Work received, but pool has not been started.");
-    throw "Pool is not initied, but work was posted to it!";
+    log(1, '[pool] Work received, but pool has not been started.');
+    throw 'Pool is not initied, but work was posted to it!';
   }
 
   // Acquire the browser along with the id of resource and work count
@@ -240,14 +239,14 @@ export const postWork = async (chart, options) => {
   } catch (error) {
     ++droppedExports;
     log(1, `[pool] Error when acquiring available entry: ${error}`);
-    throw "Error acquiring available worker in pool!";
+    throw 'Error acquiring available worker in pool!';
   }
 
-  log(4, "[pool] Acquired browser handle to use for export.");
+  log(4, '[pool] Acquired browser handle to use for export.');
 
   if (!browserHandle.browser) {
     ++droppedExports;
-    return log(1, "[pool] Resolved browser is invalid: pool setup has failed.");
+    return log(1, '[pool] Resolved browser is invalid: pool setup has failed.');
   }
 
   // Check if the work limit has been exceeded for the worker
@@ -292,13 +291,13 @@ export const postWork = async (chart, options) => {
     const workEnd = new Date().getTime();
     timeSpent += workEnd - workStart;
     spentAvarage = timeSpent / ++performedExports;
-    
+
     log(3, `[pool] Work completed in ${workEnd - workStart}ms.`);
 
     // Otherwise return the result
     return {
       data: result,
-      options,
+      options
     };
   } catch (error) {
     ++droppedExports;
@@ -359,5 +358,5 @@ export default {
   getPoolInfo,
   droppedWork: () => droppedExports,
   avarageTime: () => spentAvarage,
-  processedWorkCount: () => performedExports,
+  processedWorkCount: () => performedExports
 };

--- a/tests/node/node_test_runner.js
+++ b/tests/node/node_test_runner.js
@@ -23,10 +23,8 @@ import { join } from 'path';
 
 import 'colors';
 
-import { initDefaultOptions } from '../../lib/config.js';
 import main from '../../lib/index.js';
-import { __dirname, mergeConfigOptions } from '../../lib/utils.js';
-import { defaultConfig } from '../../lib/schemas/config.js';
+import { __dirname } from '../../lib/utils.js';
 
 console.log(
   'Highcharts Export Server Node Test Runner'.yellow,
@@ -47,15 +45,17 @@ const scenariosPath = join(__dirname, 'tests', 'node', 'scenarios');
 const files = readdirSync(scenariosPath);
 
 (async () => {
-  // Get the default options
-  const defaultOptions = initDefaultOptions(defaultConfig);
-
-  // Disable export server logging
-  defaultOptions.logging.level = 0;
-  defaultOptions.pool.queueSize = files.length;
+  const options = {
+    logging: {
+      level: 0 // disable export server logging
+    },
+    pool: {
+      queueSize: files.length
+    }
+  };
 
   // Init pool with the default options
-  await main.initPool(defaultOptions);
+  await main.initPool(options);
 
   let testCounter = 0;
   let failsCouter = 0;
@@ -72,35 +72,11 @@ const files = readdirSync(scenariosPath);
             readFileSync(join(scenariosPath, file))
           );
 
-          let options;
-          if (fileOptions.svg) {
-            options = initDefaultOptions(defaultConfig);
-            options.export.type = fileOptions.type || options.export.type;
-            options.export.scale = fileOptions.scale || options.export.scale;
-            options.payload = {
-              svg: fileOptions.svg
-            };
-          } else {
-            // Get the content of a file and merge it into the default options
-            options = mergeConfigOptions(
-              initDefaultOptions(defaultConfig),
-              fileOptions,
-              ['options', 'resources', 'globalOptions', 'themeOptions']
-            );
-          }
-
-          // Prepare an outfile path
-          options.export.outfile = join(
-            resultsPath,
-            options.export?.outfile ||
-              file.replace('.json', `.${options.export?.type || '.png'}`)
-          );
-
           // The start date of a startExport function run
           const startTime = new Date().getTime();
 
           // Start the export process
-          main.startExport(options, (info, error) => {
+          main.startExport(fileOptions, (info, error) => {
             // Set the end time
             const endTime = new Date().getTime();
 


### PR DESCRIPTION
### Description
For now, the `readme.md` file included in the repository shows a way to use the `highcharts-export-server` as a node module which is no longer working in the latest `v3.0.0`.

### Tasks
- [ ] Fix eslint/prettier issues (e.x. single quotes instead of double quotes)
- [x] Move the initialization of options with default options to methods `initPool` and `startExport`
- [ ] Improve the code 
- [ ] Update readme.md
