### PR TITLE
enhancement/puppeteer-as-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ The export server can also be used as a node module to simplify integrations:
     };
 
     // Initialize a pool of workers
-    exporter.initPool();
+    await exporter.initPool();
 
     // Perform an export
     exporter.startExport(exportSettings, function (err, res) {
@@ -542,8 +542,7 @@ The export server can also be used as a node module to simplify integrations:
         // If the output is not PDF or SVG, it will be base64 encoded (res.data).
         // If the output is a PDF or SVG, it will contain a filename (res.filename).
 
-        // The pool is automatically killed unless you set listenToProcessExits to 0 
-        // in which case you can call exporter.killPool();
+        exporter.killPool();
     });
 
 ## Node.js API Reference

--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ The export server can also be used as a node module to simplify integrations:
         // If the output is not PDF or SVG, it will be base64 encoded (res.data).
         // If the output is a PDF or SVG, it will contain a filename (res.filename).
 
+        // Kill the pool when we're done with it.
         exporter.killPool();
     });
 

--- a/README.md
+++ b/README.md
@@ -504,48 +504,46 @@ Run the below in a terminal after running `highcharts-export-server --enableServ
 
 The export server can also be used as a node module to simplify integrations:
 
-    //Include the exporter module
+    // Import the Export Server module
     const exporter = require('highcharts-export-server');
 
-    //Export settings
-    var exportSettings = {
-        type: 'png',
-        options: {
-            title: {
-                text: 'My Chart'
-            },
-            xAxis: {
-                categories: ["Jan", "Feb", "Mar", "Apr", "Mar", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-            },
-            series: [
-                {
-                    type: 'line',
-                    data: [1, 3, 2, 4]
-                },
-                {
-                    type: 'line',
-                    data: [5, 3, 4, 2]
-                }
-            ]
+    // Initialize export settings with your chart's config
+    // Export settings correspond to the available CLI arguments described above.
+    const exportSettings = {
+        export: {
+          type: 'png',
+          options: {
+              title: {
+                  text: 'My Chart'
+              },
+              xAxis: {
+                  categories: ["Jan", "Feb", "Mar", "Apr", "Mar", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+              },
+              series: [
+                  {
+                      type: 'line',
+                      data: [1, 3, 2, 4]
+                  },
+                  {
+                      type: 'line',
+                      data: [5, 3, 4, 2]
+                  }
+              ]
+          }
         }
     };
 
-    //Set up a pool of workers
+    // Initialize a pool of workers
     exporter.initPool();
 
-    //Perform an export
-    /*
-        Export settings corresponds to the available CLI arguments described
-        above.
-    */
+    // Perform an export
     exporter.export(exportSettings, function (err, res) {
-        //The export result is now in res.
-        //If the output is not PDF or SVG, it will be base64 encoded (res.data).
-        //If the output is a PDF or SVG, it will contain a filename (res.filename).
+        // The export result is now in res.
+        // If the output is not PDF or SVG, it will be base64 encoded (res.data).
+        // If the output is a PDF or SVG, it will contain a filename (res.filename).
 
-        //Kill the pool when we're done with it, and exit the application
-        exporter.killPool();
-        process.exit(1);
+        // The pool is automatically killed unless you set listenToProcessExits to 0 
+        // in which case you can call exporter.killPool();
     });
 
 ## Node.js API Reference

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ The export server can also be used as a node module to simplify integrations:
     await exporter.initPool();
 
     // Perform an export
-    exporter.startExport(exportSettings, function (err, res) {
+    exporter.startExport(exportSettings, function (res, err) {
         // The export result is now in res.
         // If the output is not PDF or SVG, it will be base64 encoded (res.data).
         // If the output is a PDF or SVG, it will contain a filename (res.filename).

--- a/README.md
+++ b/README.md
@@ -511,25 +511,25 @@ The export server can also be used as a node module to simplify integrations:
     // Export settings correspond to the available CLI arguments described above.
     const exportSettings = {
         export: {
-          type: 'png',
-          options: {
-              title: {
-                  text: 'My Chart'
-              },
-              xAxis: {
-                  categories: ["Jan", "Feb", "Mar", "Apr", "Mar", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-              },
-              series: [
-                  {
-                      type: 'line',
-                      data: [1, 3, 2, 4]
-                  },
-                  {
-                      type: 'line',
-                      data: [5, 3, 4, 2]
-                  }
-              ]
-          }
+            type: 'png',
+            options: {
+                title: {
+                    text: 'My Chart'
+                },
+                xAxis: {
+                    categories: ["Jan", "Feb", "Mar", "Apr", "Mar", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+                },
+                series: [
+                    {
+                        type: 'line',
+                        data: [1, 3, 2, 4]
+                    },
+                    {
+                        type: 'line',
+                        data: [5, 3, 4, 2]
+                    }
+                ]
+            }
         }
     };
 
@@ -537,7 +537,7 @@ The export server can also be used as a node module to simplify integrations:
     exporter.initPool();
 
     // Perform an export
-    exporter.export(exportSettings, function (err, res) {
+    exporter.startExport(exportSettings, function (err, res) {
         // The export result is now in res.
         // If the output is not PDF or SVG, it will be base64 encoded (res.data).
         // If the output is a PDF or SVG, it will contain a filename (res.filename).

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -26,6 +26,7 @@ import {
   toBoolean,
   wrapAround
 } from './utils.js';
+import { initExportSettings } from './config.js';
 
 let allowCodeExecution = false;
 
@@ -314,13 +315,16 @@ const exportAsString = (stringToExport, options, endCallback) => {
 /**
  * Starts an exporting process
  *
- * @param {object} options - All options object.
+ * @param {object} settings - Settings for export.
  * @param {function} endCallback - The function to call when exporting is done.
  */
 export default {
-  startExport: async (options, endCallback) => {
+  startExport: async (settings, endCallback) => {
     // Starting exporting process message
     log(4, '[chart] Starting exporting process.');
+
+    // Initialize options 
+    const options = initExportSettings(settings);
 
     // Get the export options
     const exportOptions = options.export;

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -17,7 +17,6 @@ import { readFile, readFileSync } from 'fs';
 import { log } from './logger.js';
 import { postWork } from './pool.js';
 import {
-  deepCopy,
   clearText,
   fixType,
   handleResources,

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -17,6 +17,7 @@ import { readFile, readFileSync } from 'fs';
 import { log } from './logger.js';
 import { postWork } from './pool.js';
 import {
+  deepCopy,
   clearText,
   fixType,
   handleResources,
@@ -29,6 +30,8 @@ import {
 import { initExportSettings } from './config.js';
 
 let allowCodeExecution = false;
+
+let poolOptions = {};
 
 /**
  * Function for choosing chart size and scale based on options prioritization.
@@ -324,7 +327,7 @@ export default {
     log(4, '[chart] Starting exporting process.');
 
     // Initialize options 
-    const options = initExportSettings(settings);
+    const options = initExportSettings(settings, poolOptions);
 
     // Get the export options
     const exportOptions = options.export;
@@ -396,6 +399,9 @@ export default {
   getAllowCodeExecution: () => allowCodeExecution,
   setAllowCodeExecution: (value) => {
     allowCodeExecution = toBoolean(value);
+  },
+  setPoolOptions: (options) => {
+    poolOptions = options;
   },
   findChartSize
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -168,23 +168,6 @@ export const manualConfiguration = async (configFileName) => {
 };
 
 /**
- * Merges user export settings with default export settings.
- * Automatically merges 'options', 'globalOptions', 'themeOptions', 'resources'
- * without going down recursively.
- *
- * @param {*} exportOptions - User settings for export.
- * @return {object} - User settings merged with default export settings.
- */
-export const getDefaultOptions = (exportOptions, poolOptions) => {
-  return mergeConfigOptions(
-    poolOptions,
-    exportOptions,
-    // Omit going down recursively with the belows
-    ['options', 'globalOptions', 'themeOptions', 'resources']
-  );
-}
-
-/**
  * Inits default options recursively.
  *
  * @param {any} items - Items to update options from.

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,8 +17,8 @@ import { existsSync, readFileSync, promises as fsPromises } from 'fs';
 import prompts from 'prompts';
 
 import { log } from './logger.js';
-import { mergeConfigOptions } from './utils.js';
 
+import { deepCopy, mergeConfigOptions } from './utils.js';
 import { defaultConfig, promptsConfig } from './schemas/config.js';
 
 /**
@@ -168,6 +168,23 @@ export const manualConfiguration = async (configFileName) => {
 };
 
 /**
+ * Merges user export settings with default export settings.
+ * Automatically merges 'options', 'globalOptions', 'themeOptions', 'resources'
+ * without going down recursively.
+ *
+ * @param {*} exportOptions - User settings for export.
+ * @return {object} - User settings merged with default export settings.
+ */
+export const getDefaultOptions = (exportOptions, poolOptions) => {
+  return mergeConfigOptions(
+    poolOptions,
+    exportOptions,
+    // Omit going down recursively with the belows
+    ['options', 'globalOptions', 'themeOptions', 'resources']
+  );
+}
+
+/**
  * Inits default options recursively.
  *
  * @param {any} items - Items to update options from.
@@ -185,26 +202,28 @@ export const initDefaultOptions = (items) => {
 
 /**
  * Initializes options for the `startExport` method by merging user options
- * with the default options.
+ * with the default options and pool options.
  *
- * @param {any} userOptions - User options for exporting.
+ * @param {any} exportOptions - User options for exporting.
+ * @param {any} poolOptions - Options of the pool which is used for export.
  * @return {object} - User options merged with default options.
  */
-export const initExportSettings = (userOptions) => {
+export const initExportSettings = (exportOptions, poolOptions = {}) => {
   let options = {};
 
-  if (userOptions.svg) {
-    options = initDefaultOptions(defaultConfig);
-    options.export.type = userOptions.type || userOptions.export.type;
-    options.export.scale = userOptions.scale || userOptions.export.scale;
+  if (exportOptions.svg) {
+    options = poolOptions; // default poolOptions
+    options.export.type = exportOptions.type || exportOptions.export.type;
+    options.export.scale = exportOptions.scale || exportOptions.export.scale;
     options.payload = {
-      svg: userOptions.svg
+      svg: exportOptions.svg
     };
   } else {
     options = mergeConfigOptions(
-      initDefaultOptions(defaultConfig),
-      userOptions,
-      ['options', 'resources', 'globalOptions', 'themeOptions']
+      poolOptions,
+      exportOptions,
+      // Omit going down recursively with the belows
+      ['options', 'globalOptions', 'themeOptions', 'resources']
     );
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,7 @@ import prompts from 'prompts';
 import { log } from './logger.js';
 import { mergeConfigOptions } from './utils.js';
 
-import { promptsConfig } from './schemas/config.js';
+import { defaultConfig, promptsConfig } from './schemas/config.js';
 
 /**
  * Loads the configuration from JSON file.
@@ -183,8 +183,38 @@ export const initDefaultOptions = (items) => {
   return options;
 };
 
+/**
+ * Initializes options for the `startExport` method by merging user options
+ * with the default options.
+ *
+ * @param {any} userOptions - User options for exporting.
+ * @return {object} - User options merged with default options.
+ */
+export const initExportSettings = (userOptions) => {
+  let options = {};
+
+  if (userOptions.svg) {
+    options = initDefaultOptions(defaultConfig);
+    options.export.type = userOptions.type || userOptions.export.type;
+    options.export.scale = userOptions.scale || userOptions.export.scale;
+    options.payload = {
+      svg: userOptions.svg
+    };
+  } else {
+    options = mergeConfigOptions(
+      initDefaultOptions(defaultConfig),
+      userOptions,
+      ['options', 'resources', 'globalOptions', 'themeOptions']
+    );
+  }
+
+  options.export.outfile = options.export?.outfile || `chart.${options.export?.type || '.png'}`;
+  return options;
+}
+
 export default {
   loadConfigFile,
   manualConfiguration,
-  initDefaultOptions
+  initDefaultOptions,
+  initExportSettings
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,8 +18,8 @@ import prompts from 'prompts';
 
 import { log } from './logger.js';
 
-import { deepCopy, mergeConfigOptions } from './utils.js';
-import { defaultConfig, promptsConfig } from './schemas/config.js';
+import { mergeConfigOptions } from './utils.js';
+import { promptsConfig } from './schemas/config.js';
 
 /**
  * Loads the configuration from JSON file.

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,8 +39,10 @@ export default {
       ['options', 'globalOptions', 'themeOptions', 'resources']
     ),
   initPool: async (options = {}) => {
+    const defaultOptions = initDefaultOptions(defaultConfig);
+
     // Load an optional config file
-    options = await loadConfigFile(options);
+    options = await loadConfigFile(mergeConfigOptions(defaultOptions, options));
 
     // Set the allowCodeExecution per export module scope
     chart.setAllowCodeExecution(

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,13 +31,6 @@ export default {
   startExport: chart.startExport,
   startServer: start,
   killPool: killAll,
-  getDefaultOptions: (exportSettings) =>
-    mergeConfigOptions(
-      initDefaultOptions(defaultConfig),
-      exportSettings,
-      // Omit going down recursively with the belows
-      ['options', 'globalOptions', 'themeOptions', 'resources']
-    ),
   initPool: async (options = {}) => {
     const defaultOptions = initDefaultOptions(defaultConfig);
 
@@ -71,6 +64,8 @@ export default {
       },
       puppeteerArgs: options.puppeteer?.args || []
     });
+
+    chart.setPoolOptions(options);
 
     // Return updated options
     return options;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -22,6 +22,7 @@ import {
 import { log } from './logger.js';
 
 import puppeteerExport from './export.js';
+import chart from './chart.js';
 
 let performedExports = 0;
 let exportAttempts = 0;
@@ -230,6 +231,8 @@ export function attachProcessExitListeners() {
  */
 export async function killAll() {
   log(3, '[pool] Killing all workers.');
+
+  chart.setPoolOptions({});
 
   // Close browser instance
   try {

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -405,6 +405,12 @@ export const defaultConfig = {
         'Set to false in order to skip attaching process.exit handlers.'
     }
   },
+  payload: {
+    svg: false,
+    b64: false,
+    dataOptions: false,
+    noDownload: false
+  },
   logging: {
     level: {
       envLink: 'HIGHCHARTS_LOG_LEVEL',

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -406,10 +406,7 @@ export const defaultConfig = {
     }
   },
   payload: {
-    svg: false,
-    b64: false,
-    dataOptions: false,
-    noDownload: false
+
   },
   logging: {
     level: {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -242,6 +242,28 @@ export const mapToNewConfig = async (oldOptions) => {
 };
 
 /**
+ * Creates and returns a deep copy of the given object.
+ *
+ * @param {object} object - Object to copy.
+ * @return {object} - Deep copy of the object.
+ */
+export const deepCopy = (obj) => {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  const copy = Array.isArray(obj) ? [] : {};
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      copy[key] = deepCopy(obj[key]);
+    }
+  }
+
+  return copy;
+}
+
+/**
  * Merges the new options to the options object. It omits undefined values.
  *
  * @param {object} options - Old options.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -272,15 +272,18 @@ export const deepCopy = (obj) => {
  * merged.
  */
 export const mergeConfigOptions = (options, newOptions, absoluteProps = []) => {
+  const mergedOptions = deepCopy(options);
+
   for (const [key, value] of Object.entries(newOptions)) {
-    options[key] =
+    mergedOptions[key] =
       isObject(value) && !absoluteProps.includes(key)
-        ? mergeConfigOptions(options[key], value, absoluteProps)
+        ? mergeConfigOptions(mergedOptions[key], value, absoluteProps)
         : value !== undefined
         ? value
-        : options[key];
+        : mergedOptions[key];
   }
-  return options;
+
+  return mergedOptions;
 };
 
 /**

--- a/tests/node/node_test_runner.js
+++ b/tests/node/node_test_runner.js
@@ -26,8 +26,6 @@ import 'colors';
 import main from '../../lib/index.js';
 import { __dirname } from '../../lib/utils.js';
 
-import chart from '../../lib/chart.js';
-
 console.log(
   'Highcharts Export Server Node Test Runner'.yellow,
   '\nThis tool simulates node module execution by using selected'.green,

--- a/tests/node/node_test_runner.js
+++ b/tests/node/node_test_runner.js
@@ -23,10 +23,10 @@ import { join } from 'path';
 
 import 'colors';
 
-import { initDefaultOptions } from '../../lib/config.js';
 import main from '../../lib/index.js';
-import { __dirname, mergeConfigOptions } from '../../lib/utils.js';
-import { defaultConfig } from '../../lib/schemas/config.js';
+import { __dirname } from '../../lib/utils.js';
+
+import chart from '../../lib/chart.js';
 
 console.log(
   'Highcharts Export Server Node Test Runner'.yellow,

--- a/tests/node/node_test_runner.js
+++ b/tests/node/node_test_runner.js
@@ -47,15 +47,15 @@ const scenariosPath = join(__dirname, 'tests', 'node', 'scenarios');
 const files = readdirSync(scenariosPath);
 
 (async () => {
-  // Get the default options
-  const defaultOptions = initDefaultOptions(defaultConfig);
-
-  // Disable export server logging
-  defaultOptions.logging.level = 0;
-  defaultOptions.pool.queueSize = files.length;
-
-  // Init pool with the default options
-  await main.initPool(defaultOptions);
+  // Initialize pool with disabled logging
+  await main.initPool({
+    logging: {
+      level: 0
+    },
+    pool: {
+      queueSize: files.length
+    }
+  });
 
   let testCounter = 0;
   let failsCouter = 0;
@@ -72,35 +72,11 @@ const files = readdirSync(scenariosPath);
             readFileSync(join(scenariosPath, file))
           );
 
-          let options;
-          if (fileOptions.svg) {
-            options = initDefaultOptions(defaultConfig);
-            options.export.type = fileOptions.type || options.export.type;
-            options.export.scale = fileOptions.scale || options.export.scale;
-            options.payload = {
-              svg: fileOptions.svg
-            };
-          } else {
-            // Get the content of a file and merge it into the default options
-            options = mergeConfigOptions(
-              initDefaultOptions(defaultConfig),
-              fileOptions,
-              ['options', 'resources', 'globalOptions', 'themeOptions']
-            );
-          }
-
-          // Prepare an outfile path
-          options.export.outfile = join(
-            resultsPath,
-            options.export?.outfile ||
-              file.replace('.json', `.${options.export?.type || '.png'}`)
-          );
-
           // The start date of a startExport function run
           const startTime = new Date().getTime();
 
           // Start the export process
-          main.startExport(options, (info, error) => {
+          main.startExport(fileOptions, (info, error) => {
             // Set the end time
             const endTime = new Date().getTime();
 


### PR DESCRIPTION
## Description
For now, the `readme.md` file included in the repository shows a way to use the `highcharts-export-server` as a node module which is no longer working in the latest v3.0.0.

The main problem is that since 3.0.0 we initialize default settings inside `initPool` and `startExport` which are supposed to be easy-to-use by the users. Merging `userOptions` with `defaultOptions` should take place somewhere else - the users should not worry about it.

- I've added the `initExportSettings` method which takes care of merging `userOptions` with `defaultOptions` for `chart.startExport`
- I've added initialization of the options inside the `lib/index.js` `initPool()` method

## Tasks
- [x] Add `initExportSettings` method
- [x] Update `readme.md`