### PR TITLE
419/height-width-css

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -175,33 +175,8 @@
         new Function(exportOptions.customCode.customCode)();
       }
 
-      // When straight inject, the size is set through CSS only
-      let injCSS = false;
-
-      if (exportOptions.export.strInj) {
-        const injCSS = document.createElement('style');
-
-        injCSS.textContent = `
-          #chart-container {
-            height: ${chart.height}px;
-            max-width: ${chart.width}px;
-          }
-
-          #chart-container #container{
-            height: ${chart.height}px;
-            max-width: ${chart.width}px;
-          }
-        `;
-
-        document.head.appendChild(injCSS);
-      }
-
+      // Create a chart
       createChart(chartOptions, exportOptions);
-
-      // Remove the injected CSS
-      if (injCSS) {
-        document.head.removeChild(injCSS);
-      }
     }
   </script>
 </html>


### PR DESCRIPTION
Removed setting height and width through the CSS for the straight inject, touch #419.

FIXES:
- Unnecessary height and width setting through CSS for straight inject cases.