### PR TITLE
bugfix/442-timezone-momentjs

### DIFF
--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -118,7 +118,8 @@ export const defaultConfig = {
     },
     scripts: {
       value: [
-        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js'
+        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.34/moment-timezone-with-data.min.js'
       ],
       type: 'string[]',
       description:


### PR DESCRIPTION
Fixed #442, added moment-timezone custom script for the `time.timezone` option.

---
The `time.timezone` option requires two scripts: 
- the main `moment.js` script
- the `moment-timezone.js` script which contains timezone data

Here's a **demo:** https://jsfiddle.net/BlackLabel/39a48f2s/
- if you try running the demo without the second script, it will throw an error (the same error that is thrown on the Export Server).

In my opinion, if we include `moment.js` by default in the `lib/schemas/config.js -> defaultConfig`, we should include the `moment-timezone` by default as well.