### PR TITLE
devops/github-action-build-dist

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,33 @@
+name: Build and Push
+
+on:
+  push:
+    branches:
+      - stable
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16.4.0'
+
+    - name: Install Dependencies
+      run: npm install
+
+    - name: Build Project
+      run: npm run build
+
+    - name: Commit and Push /dist Directory
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add dist/
+        git commit -m "Build the dist files after merge."
+        git push

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: '16.4.0'
 
     - name: Install Dependencies
-      run: npm install
+      run: npm ci
 
     - name: Build Project
       run: npm run build

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@4
       with:
         node-version: '16.4.0'
 


### PR DESCRIPTION
#430, added a Github Action (`build-and-push`) which triggers after there has been a push to the `stable` branch and:
1. checks out the repository
2. sets up NodeJS
3. installs all the dependencies (`npm i`)
4. builds the `/dist` directory (`npm run build`)
5. commits & pushes the `/dist` directory

so that the `/dist` folder does not have to be built manually.

### To-do:
- [ ] need to test whether this works