### PR TITLE
enhancement/250-scale-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ These are set as variables in your environment. They take precedence over option
 - `EXPORT_DEFAULT_CONSTR`: The constructor to use. Can be chart, stockChart, mapChart or ganttChart.
 - `EXPORT_DEFAULT_HEIGHT`: The height of the exported chart. Overrides the option in the chart settings.
 - `EXPORT_DEFAULT_WIDTH`: The width of the exported chart. Overrides the option in the chart settings.
-- `EXPORT_DEFAULT_SCALE`: The scale of the exported chart. Ranges between 1 and 5.
+- `EXPORT_DEFAULT_SCALE`: The scale of the exported chart. Ranges between 0.1 and 5.0.
 
 ### Highcharts config
 - `HIGHCHARTS_VERSION`: Highcharts version to use.
@@ -341,7 +341,7 @@ _Available options:_
 - `--constr`: The constructor to use. Can be chart, stockChart, mapChart or ganttChart (defaults to `chart`).
 - `--height`: The height of the exported chart. Overrides the option in the chart settings (defaults to `600`).
 - `--width`: The width of the exported chart. Overrides the option in the chart settings (defaults to `400`).
-- `--scale`: The scale of the exported chart. Ranges between 1 and 5 (defaults to `1`).
+- `--scale`: The scale of the exported chart. Ranges between 0.1 and 5.0 (defaults to `1`).
 - `--globalOptions`: A stringified JSON or a filename with options to be passed into the Highcharts.setOptions (defaults to `false`).
 - `--themeOptions`: A stringified JSON or a filename with theme options to be passed into the Highcharts.setOptions (defaults to `false`).
 - `--batch`: Starts a batch job. A string that contains input/output pairs: "in=out;in=out;.." (defaults to `false`).

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -22,7 +22,6 @@ import {
   handleResources,
   isCorrectJSON,
   optionsStringify,
-  roundNumber,
   toBoolean,
   wrapAround
 } from './utils.js';

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -189,19 +189,15 @@ export const findChartSize = (options) => {
   const globalOptions = isCorrectJSON(options.export?.globalOptions);
 
   // Secure scale value
-  let scale = roundNumber(
+  let scale =
     options.export?.scale ||
-      exporting?.scale ||
-      globalOptions?.exporting?.scale ||
-      options.export?.defaultScale ||
-      1
-  );
+    exporting?.scale ||
+    globalOptions?.exporting?.scale ||
+    options.export?.defaultScale ||
+    1;
 
-  if (scale > 5) {
-    scale = 5;
-  } else if (scale < 0.1) {
-    scale = 1;
-  }
+  // the scale cannot be lower than 0.1 and cannot be higher than 5.0
+  scale = Math.max(0.1, Math.min(scale, 5.0));
 
   // Find chart size and scale
   return {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -349,17 +349,6 @@ export function printUsage() {
 }
 
 /**
- * Rounds number to passed precision.
- *
- * @param {number} value - Number to round.
- * @param {number} precision - A precision of rounding.
- */
-export const roundNumber = (value, precision = 1) => {
-  const multiplier = Math.pow(10, precision || 0);
-  return Math.round(+value * multiplier) / multiplier;
-};
-
-/**
  * Casts the item to boolean.
  *
  * @param {any} item - Item to be cast.
@@ -414,7 +403,6 @@ export default {
   optionsStringify,
   printLogo,
   printUsage,
-  roundNumber,
   toBoolean,
   wrapAround,
   measureTime


### PR DESCRIPTION
## Goal
The goal is to enable scales different than ints (`1.25, 0.25, 2.75, etc.`) and from a wider range (`0.1 - 5.0`) instead of `(1, 5)` range.

## Tasks
- [ ] increase the range from `(1, 5)` to `(0.1, 5.0)`
- [ ] update the readme
- [ ] test if all the scenarios work