### PR TITLE
bugfix/447-page-transparency

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -59,7 +59,8 @@ const createImage = async (page, type, encoding, clip) =>
     page.screenshot({
       type,
       encoding,
-      clip
+      clip,
+      omitBackground: true
     }),
     new Promise((resolve, reject) =>
       setTimeout(() => reject(new Error('Rasterization timeout')), 1500)


### PR DESCRIPTION
Fixed #447, it's possible now to export `.png` charts with a transparent background.