### PR TITLE
bugfix/463-transparent-background

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -61,10 +61,9 @@ const createImage = async (page, type, encoding, clip) =>
       encoding,
       clip,
 
-      // #447 - always render on a transparent page
-      // this will not affect users who do not explicitly set
-      // chart.backgroundColor to a color with opacity lower than 1
-      omitBackground: true
+      // #447, #463 - always render on a transparent page if
+      // the expected type format is PNG
+      omitBackground: type == 'png'
     }),
     new Promise((resolve, reject) =>
       setTimeout(() => reject(new Error('Rasterization timeout')), 1500)


### PR DESCRIPTION
Fixed #463, omit page background only for PNG types.