### PR TITLE
bugfix/b64-svg-export

### DIFF
--- a/lib/server/routes/export.js
+++ b/lib/server/routes/export.js
@@ -308,12 +308,13 @@ const exportHandler = (request, response) => {
     if (info.data) {
       // If only base64 is required, return it
       if (body.b64) {
-        // Check if it is already base64 or a raw SVG
-        if (type === 'pdf') {
+        // SVG Exception for the Highcharts 11.3.0 version
+        if (type === 'pdf' || type == 'svg') {
           return response.send(
             Buffer.from(info.data, 'utf8').toString('base64')
           );
         }
+
         return response.send(info.data);
       }
 


### PR DESCRIPTION
Added an exception for the base64 svg export issue.

---
Simple demo for testing: https://jsfiddle.net/oj9z8ehq/
- start the server locally
- click "download SVG" in the exporting menu

You can test it out with v11.3.0, v11.2.0 and previous versions. Everything seems to work as expected.