### PR TITLE
bugfix/ui-public-website-svg-export

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -68,7 +68,8 @@ const highexp = {};
             preview.innerHTML =
               '<img src="data:' + format.value + ';base64,' + data + '"/>';
           } else if (format.value === 'image/svg+xml') {
-            preview.innerHTML = data;
+            preview.innerHTML =
+              '<img src="data:image/svg+xml;base64,' + data + '"/>';
           } else if (format.value === 'application/pdf') {
             preview.innerHTML = '';
             try {


### PR DESCRIPTION
Fixed SVG export from the public ES website.

Related to https://github.com/highcharts/node-export-server/pull/468 and the changes in Highcharts 11.3.0 for `b64`.