### PR TITLE
Ability to change the path to the cache directory

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -23,12 +23,13 @@ import dotenv from 'dotenv';
 import HttpsProxyAgent from 'https-proxy-agent';
 import { fetch } from './fetch.js';
 
+import { defaultConfig } from './schemas/config.js';
+
 import { log } from './logger.js';
-import { __dirname } from '../lib/utils.js';
 
 dotenv.config();
 
-const cachePath = join(__dirname, '.cache');
+let cachePath = defaultConfig.other.cacheDir.value;
 
 const cache = {
   cdnURL: 'https://code.highcharts.com/',
@@ -285,9 +286,27 @@ export const checkCache = async (config) => {
   await saveConfigToManifest(config, fetchedModules);
 };
 
+/**
+ * Set the path to the cache directory.
+ *
+ * @param {string} path - The path to the cache directory.
+ */
+export const setCacheDir = (path) => {
+  if (appliedConfig) {
+    throw new Error(
+      'Unable to set the path to the cache directory after a cache has been initialized.'
+    );
+  }
+  if (path !== cachePath) {
+    log(4, `[cache] Set the new cache path ${path}.`);
+  }
+  cachePath = path;
+};
+
 export default {
   checkCache,
   updateVersion,
+  setCacheDir,
   getCache: () => cache,
   highcharts: () => cache.sources,
   version: () => cache.hcVersion

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ import {
 import { mapToNewConfig, setOptions } from './config.js';
 import { log, setLogLevel, enableFileLogging } from './logger.js';
 import { killPool, init } from './pool.js';
-import { checkCache } from './cache.js';
+import { checkCache, setCacheDir } from './cache.js';
 
 export default {
   log,
@@ -53,6 +53,9 @@ export default {
         options.logging.file || 'highcharts-export-server.log'
       );
     }
+
+    // Set the path to the cache directory
+    setCacheDir(options.other && options.other.cacheDir);
 
     // Check if cache needs to be updated
     await checkCache(options.highcharts || { version: 'latest' });

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -13,7 +13,9 @@ See LICENSE file in root for details.
 *******************************************************************************/
 
 import { join } from 'path';
-import { __dirname } from '../utils.js';
+import { fileURLToPath } from 'url';
+
+export const __dirname = fileURLToPath(new URL('../../.', import.meta.url));
 
 const defaultCachePath = join(__dirname, '.cache');
 

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -12,6 +12,11 @@ See LICENSE file in root for details.
 
 *******************************************************************************/
 
+import { join } from 'path';
+import { __dirname } from '../utils.js';
+
+const defaultCachePath = join(__dirname, '.cache');
+
 // Load .env into environment variables
 import dotenv from 'dotenv';
 
@@ -502,6 +507,11 @@ export const defaultConfig = {
       type: 'boolean',
       description:
         'Skip printing the logo on a startup. Will be replaced by a simple text.'
+    },
+    cacheDir: {
+      value: defaultCachePath,
+      type: 'string',
+      description: 'The absolute or relative path for a cache.'
     }
   },
   payload: {}
@@ -821,6 +831,12 @@ export const promptsConfig = {
       message:
         'Skip printing the logo on a startup. Will be replaced by a simple text',
       initial: defaultConfig.other.noLogo.value
+    },
+    {
+      type: 'text',
+      name: 'cacheDir',
+      message: 'The absolute or relative path for a cache.',
+      initial: defaultCachePath
     }
   ]
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,15 +13,14 @@ See LICENSE file in root for details.
 *******************************************************************************/
 
 import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
 import { join as pather } from 'path';
 
-import { defaultConfig } from '../lib/schemas/config.js';
+import { __dirname as dirname, defaultConfig } from '../lib/schemas/config.js';
 import { log } from './logger.js';
 
 const MAX_BACKOFF_ATTEMPTS = 6;
 
-export const __dirname = fileURLToPath(new URL('../.', import.meta.url));
+export const __dirname = dirname;
 
 /**
  * Clears text from whitespaces with a regex rule.


### PR DESCRIPTION
Implements the ability to change the path to the cache directory before the exporter is initialized.
Absolute and releative paths are allowed.

```
const server = require("highcharts-export-server");
options = server.setOptions({
    other: {
        cacheDir: "/tmp/highcharts"
    }
});
server..initPool(options);
```

Closes #480

Unfortunately, I'm unsure how to test this using the existing tests. All tests are run with a previously initialized server. In this case, it would be better to initialize the server before each test case.