### PR TITLE
feature/480-cache-directory-path

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -28,8 +28,6 @@ import { __dirname } from '../lib/utils.js';
 
 dotenv.config();
 
-const cachePath = join(__dirname, '.cache');
-
 const cache = {
   cdnURL: 'https://code.highcharts.com/',
   activeManifest: {},
@@ -54,7 +52,7 @@ const extractVersion = () =>
 /**
  * Saves the Highcharts part of a config to a manifest file in the cache
  *
- * @param {object} config - Highcharts related configuration object.
+ * @param {object} config - Highcharts-related configuration object.
  * @param {object} fetchedModules - An object that contains mapped names of
  * fetched Highcharts modules to use.
  */
@@ -71,7 +69,7 @@ const saveConfigToManifest = async (config, fetchedModules) => {
 
   try {
     writeFileSync(
-      join(cachePath, 'manifest.json'),
+      join(__dirname, config.cachePath, 'manifest.json'),
       JSON.stringify(newManifest),
       'utf8'
     );
@@ -192,7 +190,7 @@ const updateCache = async (config, sourcePath) => {
 
 export const updateVersion = async (newVersion) =>
   appliedConfig
-    ? await checkCache(
+    ? await checkAndUpdateCache(
         Object.assign(appliedConfig, {
           version: newVersion
         })
@@ -202,9 +200,11 @@ export const updateVersion = async (newVersion) =>
 /**
  * Fetches any missing Highcharts and dependencies
  *
- * @param {object} config - Highcharts related configuration object.
+ * @param {object} config - Highcharts-related configuration object.
  */
-export const checkCache = async (config) => {
+export const checkAndUpdateCache = async (config) => {
+  const cachePath = join(__dirname, config.cachePath);
+
   let fetchedModules;
   // Prepare paths to manifest and sources from the .cache folder
   const manifestPath = join(cachePath, 'manifest.json');
@@ -286,7 +286,7 @@ export const checkCache = async (config) => {
 };
 
 export default {
-  checkCache,
+  checkAndUpdateCache,
   updateVersion,
   getCache: () => cache,
   highcharts: () => cache.sources,

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ import {
 import { mapToNewConfig, setOptions } from './config.js';
 import { log, setLogLevel, enableFileLogging } from './logger.js';
 import { killPool, init } from './pool.js';
-import { checkCache } from './cache.js';
+import { checkAndUpdateCache } from './cache.js';
 
 export default {
   log,
@@ -55,7 +55,7 @@ export default {
     }
 
     // Check if cache needs to be updated
-    await checkCache(options.highcharts || { version: 'latest' });
+    await checkAndUpdateCache(options.highcharts || { version: 'latest' });
 
     // Init the pool
     await init({

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -132,6 +132,13 @@ export const defaultConfig = {
       type: 'boolean',
       description:
         'Should all the scripts be refetched after rerunning the server.'
+    },
+    cachePath: {
+      envLink: 'HIGHCHARTS_CACHE_PATH',
+      value: '.cache',
+      type: 'string',
+      description:
+        'The path to the cache directory. It is used to store the Highcharts scripts and custom scripts.'
     }
   },
   export: {
@@ -555,6 +562,12 @@ export const promptsConfig = {
       name: 'forceFetch',
       message: 'Should refetch all the scripts after each server rerun',
       initial: defaultConfig.highcharts.forceFetch.value
+    },
+    {
+      type: 'text',
+      name: 'cachePath',
+      message: 'The path to the cache directory',
+      initial: defaultConfig.other.cachePath.value
     }
   ],
   export: [


### PR DESCRIPTION
Added the `cachePath` (`HIGHCHARTS_CACHE_PATH`) option which allows you to change the default directory to which the scripts are saved which is a major problem on AWS Lambda where you do not have write permissions to the `.cache` directory in `node_modules` and thus, `highcharts-export-server` does not work as expected.