### PR TITLE
bugfix/492-background-color-transparent 

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -382,7 +382,7 @@ export default async (page, chart, options) => {
     if (exportOptions.type === 'svg') {
       // SVG
       data = await createSVG(page);
-    } else if (exportOptions.type === 'png' || exportOptions.type === 'jpeg') {
+    } else if (['png', 'jpeg'].includes(exportOptions.type)) {
       // PNG or JPEG
       data = await createImage(
         page,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,8 +102,9 @@ export const fixType = (type, outfile) => {
   if (outfile) {
     const outType = outfile.split('.').pop();
 
-    // Check if extension has a correct type
-    if (formats.includes(outType) && type !== outType) {
+    if (outType === 'jpg') {
+      type = 'jpeg';
+    } else if (formats.includes(outType) && type !== outType) {
       type = outType;
     }
   }


### PR DESCRIPTION
Currently, the `fixType` method if a file is given with `.jpg` and not with `.jpeg`, sets the `exportOptions.type = 'png'` which then incorrectly performs certain operations. This was a cause for the background being omitted even though we only want to omit backgrounds if the `outType == 'png'`.

## Todo
- [ ] add a unit test for the `fixType` method - check all the possible conversions

---
Closes #492.