### PR TITLE
bugfix/307-ssl-handshake

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -137,7 +137,7 @@ export const startServer = async (serverConfig) => {
 
       if (key && cert) {
         // Main server instance (HTTPS)
-        const httpsServer = https.createServer(app);
+        const httpsServer = https.createServer({ key, cert }, app);
 
         // Attach error handlers and listen to the server
         attachErrorHandlers(httpsServer);


### PR DESCRIPTION
Fixed #307, ssl now works as we pass `key` and `cert` to the https `createServer` method.