### PR TITLE
cleanup/moving-avg-message

### DIFF
--- a/lib/server/routes/health.js
+++ b/lib/server/routes/health.js
@@ -100,7 +100,10 @@ export default function addHealthRoutes(app) {
       // Moving average
       period,
       movingAverage,
-      message: `Last ${period} minutes had a success rate of ${movingAverage.toFixed(2)}%.`,
+      message:
+        isNaN(movingAverage) || !successRates.length
+          ? 'Too early to report. No exports made yet. Please check back soon.'
+          : `Last ${period} minutes had a success rate of ${movingAverage.toFixed(2)}%.`,
 
       // SVG/JSON attempts
       svgExportAttempts: stats.exportFromSvgAttempts,


### PR DESCRIPTION
A minor fix: instead of displaying: `Last 0 minutes had a success rate of NaN.`, we now display `Too early to report. No exports made yet. Please check back soon.`.