### PR TITLE
Adjust package.json for distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "require": "./dist/index.cjs"
     }
   },
+  "files": ["dist", "bin", "templates", "install.js", "lib"],
   "repository": {
     "url": "https://github.com/highcharts/node-export-server",
     "type": "git"
@@ -35,6 +36,7 @@
     "node-tests": "node ./tests/node/node_test_runner.js",
     "node-tests-single": "node ./tests/node/node_test_runner_single.js",
     "prepare": "husky || true",
+    "prepack": "npm run build",
     "build": "rollup -c",
     "unit:test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },


### PR DESCRIPTION
This now only packs required files for distribution and ensures the project is built when published.