### PR TITLE
feat/567-user-data-dir-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.0.3
+
+_New features:_
+
+- Made the temporary Puppeteer directory (`PUPPETEER_DIR`) (till now, `'./tmp'`) configurable by the user [(#567)](https://github.com/highcharts/node-export-server/issues/567)
+
 # 4.0.2
 
 _Hotfix_:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.0.1
+
+_Hotfix_:
+
+- Fixed missing 'dist' bundle in 4.0.0 on NPM.
+
 # 4.0.0
 
 _Breaking Changes:_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 4.0.2
 
+_Hotfix_:
+
+- Fixed missing 'msg' and 'public' bundle in 4.0.1 on NPM.
+
 _Fixes:_
 
 - Made chart userOptions available within `customCode` as variable `options` [(#551)](https://github.com/highcharts/node-export-server/issues/551).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.0.2
+
+_Fixes:_
+
+- Made chart userOptions available within `customCode` as variable `options` [(#551)](https://github.com/highcharts/node-export-server/issues/551).
+
 # 4.0.1
 
 _Hotfix_:

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -59,14 +59,14 @@ export function get() {
  */
 export async function create(puppeteerArgs) {
   // Get debug and other options
-  const { debug, other } = getOptions();
+  const { puppeteer, debug, other } = getOptions();
 
   // Get the debug options
   const { enable: enabledDebug, ...debugOptions } = debug;
 
   const launchOptions = {
     headless: other.browserShellMode ? 'shell' : true,
-    userDataDir: './tmp/',
+    userDataDir: puppeteer.dir,
     args: puppeteerArgs,
     handleSIGINT: false,
     handleSIGTERM: false,

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -66,7 +66,7 @@ export async function create(puppeteerArgs) {
 
   const launchOptions = {
     headless: other.browserShellMode ? 'shell' : true,
-    userDataDir: puppeteerOptions.dir,
+    userDataDir: puppeteerOptions.tempDir,
     args: puppeteerArgs,
     handleSIGINT: false,
     handleSIGTERM: false,

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -59,14 +59,14 @@ export function get() {
  */
 export async function create(puppeteerArgs) {
   // Get debug and other options
-  const { puppeteer, debug, other } = getOptions();
+  const { puppeteer: puppeteerOptions, debug, other } = getOptions();
 
   // Get the debug options
   const { enable: enabledDebug, ...debugOptions } = debug;
 
   const launchOptions = {
     headless: other.browserShellMode ? 'shell' : true,
-    userDataDir: puppeteer.dir,
+    userDataDir: puppeteerOptions.dir,
     args: puppeteerArgs,
     handleSIGINT: false,
     handleSIGTERM: false,

--- a/lib/envs.js
+++ b/lib/envs.js
@@ -64,6 +64,24 @@ const v = {
       )
       .transform((value) => (value !== '' ? value : undefined)),
 
+  // Checks if the string is a valid path directory (path format)
+  path: () =>
+    z
+      .string()
+      .trim()
+      .refine(
+        (value) => {
+          // Simplified regex to match both absolute and relative paths
+          return /^(\.\/|\.\.\/|\/|[a-zA-Z]:\\|[a-zA-Z]:\/)?([\w-]+[\\/]?)+$/.test(
+            value
+          );
+        },
+        {},
+        {
+          message: 'The string is an invalid path directory string.'
+        }
+      ),
+
   // Allows positive numbers or no value in which case the returned value will
   // be undefined
   positiveNum: () =>
@@ -128,7 +146,7 @@ export const Config = z.object({
   HIGHCHARTS_ADMIN_TOKEN: v.string(),
 
   // puppeteer
-  PUPPETEER_DIR: v.string(),
+  PUPPETEER_DIR: v.path(),
 
   // export
   EXPORT_TYPE: v.enum(['jpeg', 'png', 'pdf', 'svg']),

--- a/lib/envs.js
+++ b/lib/envs.js
@@ -127,6 +127,9 @@ export const Config = z.object({
   HIGHCHARTS_CACHE_PATH: v.string(),
   HIGHCHARTS_ADMIN_TOKEN: v.string(),
 
+  // puppeteer
+  PUPPETEER_DIR: v.string(),
+
   // export
   EXPORT_TYPE: v.enum(['jpeg', 'png', 'pdf', 'svg']),
   EXPORT_CONSTR: v.enum(['chart', 'stockChart', 'mapChart', 'ganttChart']),

--- a/lib/highcharts.js
+++ b/lib/highcharts.js
@@ -41,11 +41,6 @@ export async function triggerExport(chartOptions, options, displayErrors) {
   // prevent from polluting other exports that can happen on the same page
   Highcharts.setOptionsObj = merge(false, {}, getOptions());
 
-  // Trigger custom code
-  if (options.customLogic.customCode) {
-    new Function(options.customLogic.customCode)();
-  }
-
   // By default animation is disabled
   const chart = {
     animation: false
@@ -100,6 +95,11 @@ export async function triggerExport(chartOptions, options, displayErrors) {
   const userOptions = options.export.strInj
     ? new Function(`return ${options.export.strInj}`)()
     : chartOptions;
+  
+  // Trigger custom code
+  if (options.customLogic.customCode) {
+    new Function('options', options.customLogic.customCode)(userOptions);
+  }
 
   // Merge the globalOptions, themeOptions, options from the wrapped
   // setOptions function and user options to create the final options object

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -147,7 +147,7 @@ export const defaultConfig = {
       type: 'string[]',
       description: 'Arguments array to send to Puppeteer.'
     },
-    dir: {
+    tempDir: {
       value: './tmp/',
       type: 'string',
       envLink: 'PUPPETEER_DIR',

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -146,6 +146,12 @@ export const defaultConfig = {
       ],
       type: 'string[]',
       description: 'Arguments array to send to Puppeteer.'
+    },
+    dir: {
+      value: './tmp/',
+      type: 'string',
+      envLink: 'PUPPETEER_DIR',
+      description: 'The directory for Puppeteer to store temporary files.'
     }
   },
   highcharts: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "highcharts-export-server",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "highcharts-export-server",
-      "version": "4.0.0",
+      "version": "4.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Highsoft AS <support@highcharts.com> (http://www.highcharts.com/about)",
   "license": "MIT",
   "type": "module",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "./dist/index.esm.js",
   "engines": {
     "node": ">=18.12.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "require": "./dist/index.cjs"
     }
   },
+  "files": ["dist", "bin", "templates", "install.js", "lib"],
   "repository": {
     "url": "https://github.com/highcharts/node-export-server",
     "type": "git"
@@ -35,6 +36,7 @@
     "node-tests": "node ./tests/node/node_test_runner.js",
     "node-tests-single": "node ./tests/node/node_test_runner_single.js",
     "prepare": "husky || true",
+    "prepack": "npm run build",
     "build": "rollup -c",
     "unit:test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Highsoft AS <support@highcharts.com> (http://www.highcharts.com/about)",
   "license": "MIT",
   "type": "module",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "main": "./dist/index.esm.js",
   "engines": {
     "node": ">=18.12.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,15 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist", "bin", "templates", "install.js", "lib"],
+  "files": [
+    "dist",
+    "bin",
+    "templates",
+    "install.js",
+    "lib",
+    "msg",
+    "public"
+  ],
   "repository": {
     "url": "https://github.com/highcharts/node-export-server",
     "type": "git"

--- a/tests/unit/envs.test.js
+++ b/tests/unit/envs.test.js
@@ -59,4 +59,25 @@ describe('Environment variables should be correctly parsed', () => {
     env.HIGHCHARTS_FORCE_FETCH = 'false';
     expect(Config.partial().parse(env).HIGHCHARTS_FORCE_FETCH).toEqual(false);
   });
+
+  test('PUPPETEER_DIR should be a valid path', () => {
+    const env = { PUPPETEER_DIR: '/path/to/dir' };
+    expect(Config.partial().parse(env).PUPPETEER_DIR).toEqual('/path/to/dir');
+
+    env.PUPPETEER_DIR = '/another/path/to/dir';
+    expect(Config.partial().parse(env).PUPPETEER_DIR).toEqual(
+      '/another/path/to/dir'
+    );
+
+    env.PUPPETEER_DIR = '';
+    expect(() => Config.partial().parse(env)).toThrow();
+  });
+
+  test('PUPPETEER_DIR can be a relative path', () => {
+    const env = { PUPPETEER_DIR: './tmp/' };
+    expect(Config.partial().parse(env).PUPPETEER_DIR).toEqual('./tmp/');
+
+    env.PUPPETEER_DIR = '../custom-tmp/';
+    expect(Config.partial().parse(env).PUPPETEER_DIR).toEqual('../custom-tmp/');
+  });
 });


### PR DESCRIPTION
Added #567, PUPPETEER_DIR made configurable.

---
## Tasks
- [x] add `PUPPETEER_DIR` option
- [x] write a unit test for it being configurable
- [x] write a proper verifier in `envs.js`
- [x] test out the solution manually
- [x] update the changelog