### PR TITLE
Support absolute cache paths

### DIFF
--- a/install.js
+++ b/install.js
@@ -15,7 +15,7 @@ See LICENSE file in root for details.
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-import { __dirname } from './lib/utils.js';
+import { __dirname } from './lib/constants.js';
 
 import 'colors';
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -21,7 +21,7 @@ import { getCachePath } from './cache.js';
 import { getOptions } from './config.js';
 import { setupHighcharts } from './highcharts.js';
 import { log, logWithStack } from './logger.js';
-import { __dirname } from './utils.js';
+import { __dirname } from './constants.js';
 
 import ExportError from './errors/ExportError.js';
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -25,7 +25,7 @@ import { getOptions } from './config.js';
 import { envs } from './envs.js';
 import { fetch } from './fetch.js';
 import { log } from './logger.js';
-import { __dirname } from './utils.js';
+import { __dirname } from './constants.js';
 
 import ExportError from './errors/ExportError.js';
 
@@ -81,9 +81,11 @@ export const saveConfigToManifest = async (config, fetchedModules) => {
   cache.activeManifest = newManifest;
 
   log(3, '[cache] Writing a new manifest.');
+
+  const cachePath = getCachePath();
   try {
     writeFileSync(
-      join(__dirname, config.cachePath, 'manifest.json'),
+      join(cachePath, 'manifest.json'),
       JSON.stringify(newManifest),
       'utf8'
     );
@@ -306,7 +308,7 @@ export const updateVersion = async (newVersion) => {
  */
 export const checkAndUpdateCache = async (options) => {
   const { highcharts, server } = options;
-  const cachePath = join(__dirname, highcharts.cachePath);
+  const cachePath = getCachePath();
 
   let fetchedModules;
   // Prepare paths to manifest and sources from the .cache folder
@@ -387,8 +389,7 @@ export const checkAndUpdateCache = async (options) => {
   await saveConfigToManifest(highcharts, fetchedModules);
 };
 
-export const getCachePath = () =>
-  join(__dirname, getOptions().highcharts.cachePath);
+export const getCachePath = () => getOptions().highcharts.cachePath;
 
 export const getCache = () => cache;
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,16 +12,10 @@ See LICENSE file in root for details.
 
 *******************************************************************************/
 
-import { join } from 'path';
+import { fileURLToPath } from 'url';
 
-import { __dirname } from '../../constants.js';
+export const __dirname = fileURLToPath(new URL('../.', import.meta.url));
 
-/**
- * Adds the GET / route for a UI when enabled on the export server.
- */
-export default (app) =>
-  !app
-    ? false
-    : app.get('/', (request, response) => {
-        response.sendFile(join(__dirname, 'public', 'index.html'));
-      });
+export default {
+  __dirname
+};

--- a/lib/highcharts.js
+++ b/lib/highcharts.js
@@ -95,7 +95,7 @@ export async function triggerExport(chartOptions, options, displayErrors) {
   const userOptions = options.export.strInj
     ? new Function(`return ${options.export.strInj}`)()
     : chartOptions;
-  
+
   // Trigger custom code
   if (options.customLogic.customCode) {
     new Function('options', options.customLogic.customCode)(userOptions);

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -12,6 +12,10 @@ See LICENSE file in root for details.
 
 *******************************************************************************/
 
+import { join } from 'path';
+
+import { __dirname } from '../constants.js';
+
 // Possible names for Highcharts scripts
 export const scriptsNames = {
   core: ['highcharts', 'highcharts-more', 'highcharts-3d'],
@@ -192,7 +196,7 @@ export const defaultConfig = {
         'The flag to determine whether to refetch all scripts after each server rerun.'
     },
     cachePath: {
-      value: '.cache',
+      value: join(__dirname, '.cache'),
       type: 'string',
       envLink: 'HIGHCHARTS_CACHE_PATH',
       description:

--- a/lib/server/routes/health.js
+++ b/lib/server/routes/health.js
@@ -19,7 +19,7 @@ import { log } from '../../logger.js';
 import { version } from '../../cache.js';
 import { addInterval } from '../../intervals.js';
 import pool from '../../pool.js';
-import { __dirname } from '../../utils.js';
+import { __dirname } from '../../constants.js';
 
 const pkgFile = JSON.parse(readFileSync(pather(__dirname, 'package.json')));
 

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -24,7 +24,7 @@ import multer from 'multer';
 import errorHandler from './error.js';
 import rateLimit from './rate_limit.js';
 import { log, logWithStack } from '../logger.js';
-import { __dirname } from '../utils.js';
+import { __dirname } from '../constants.js';
 
 import vSwitchRoute from './routes/change_hc_version.js';
 import exportRoutes from './routes/export.js';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,8 +21,6 @@ import { log, logWithStack } from './logger.js';
 
 const MAX_BACKOFF_ATTEMPTS = 6;
 
-export const __dirname = fileURLToPath(new URL('../.', import.meta.url));
-
 /**
  * Clears and standardizes text by replacing multiple consecutive whitespace
  * characters with a single space and trimming any leading or trailing
@@ -449,7 +447,6 @@ export const measureTime = () => {
 };
 
 export default {
-  __dirname,
   clearText,
   expBackoff,
   fixType,

--- a/package.json
+++ b/package.json
@@ -14,15 +14,7 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": [
-    "dist",
-    "bin",
-    "templates",
-    "install.js",
-    "lib",
-    "msg",
-    "public"
-  ],
+  "files": ["dist", "bin", "templates", "install.js", "lib", "msg", "public"],
   "repository": {
     "url": "https://github.com/highcharts/node-export-server",
     "type": "git"

--- a/tests/cli/cli_test_runner.js
+++ b/tests/cli/cli_test_runner.js
@@ -19,7 +19,7 @@ import { promisify } from 'util';
 
 import 'colors';
 
-import { __dirname } from '../../lib/utils.js';
+import { __dirname } from '../../lib/constants.js';
 
 // Convert from callback to promise
 const spawn = promisify(exec);

--- a/tests/cli/cli_test_runner_single.js
+++ b/tests/cli/cli_test_runner_single.js
@@ -18,7 +18,7 @@ import { basename, join } from 'path';
 
 import 'colors';
 
-import { __dirname } from '../../lib/utils.js';
+import { __dirname } from '../../lib/constants.js';
 
 // Test runner message
 console.log(

--- a/tests/http/http_test_runner.js
+++ b/tests/http/http_test_runner.js
@@ -25,7 +25,8 @@ import { join } from 'path';
 import 'colors';
 
 import { fetch } from '../../lib/fetch.js';
-import { __dirname, clearText } from '../../lib/utils.js';
+import { __dirname } from '../../lib/constants.js';
+import { clearText } from '../../lib/utils.js';
 
 // Test runner message
 console.log(

--- a/tests/http/http_test_runner_single.js
+++ b/tests/http/http_test_runner_single.js
@@ -19,7 +19,8 @@ import { basename, join } from 'path';
 import 'colors';
 
 import { fetch } from '../../lib/fetch.js';
-import { __dirname, clearText } from '../../lib/utils.js';
+import { __dirname } from '../../lib/constants.js';
+import { clearText } from '../../lib/utils.js';
 
 // Test runner message
 console.log(

--- a/tests/node/node_test_runner.js
+++ b/tests/node/node_test_runner.js
@@ -24,7 +24,7 @@ import { basename, join } from 'path';
 import 'colors';
 
 import exporter from '../../lib/index.js';
-import { __dirname } from '../../lib/utils.js';
+import { __dirname } from '../../lib/constants.js';
 
 console.log(
   'Highcharts Export Server Node Test Runner'.yellow.bold.underline,

--- a/tests/node/node_test_runner_single.js
+++ b/tests/node/node_test_runner_single.js
@@ -18,7 +18,7 @@ import { basename, join } from 'path';
 import 'colors';
 
 import exporter from '../../lib/index.js';
-import { __dirname } from '../../lib/utils.js';
+import { __dirname } from '../../lib/constants.js';
 
 console.log(
   'Highcharts Export Server Node Test Runner'.yellow.bold.underline,

--- a/tests/other/side_by_side.js
+++ b/tests/other/side_by_side.js
@@ -19,7 +19,7 @@ import { join } from 'path';
 
 import 'colors';
 
-import { __dirname } from '../../lib/utils.js';
+import { __dirname } from '../../lib/constants.js';
 
 // Results paths
 const resultsPath = join(__dirname, 'tests', 'other', '_results');


### PR DESCRIPTION
For read only systems it's common to use `/tmp` for caching and temporary files. This contribution enables the user to express an absolute path rather than only a relative path. The default remains the same, but simply expresses the path as absolute instead of relative.

`__dirname` is moved to an isolated file to avoid a circular dependency now that it's imported in `config.js`.