### PR TITLE
public/add-fair-usage-policy-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Note:** If you use the public Export Server at [https://export.highcharts.com](https://export.highcharts.com) you should read our [Terms of use and Fair Usage Policy](https://www.highcharts.com/docs/export-module/privacy-disclaimer-export).
+**Note:** If you use the public Export Server at [https://export.highcharts.com](https://export.highcharts.com) you should read our [Terms of use and Fair Usage Policy](https://www.highcharts.com/docs/export-module/privacy-disclaimer-export). Note that a valid Highcharts License is required to do exports.
 
 # Highcharts Node.js Export Server
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,52 +1,42 @@
 <!doctype html>
 <html>
-  <head>
-    <title>Highcharts Export Server</title>
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="https://www.highcharts.com/demo/static/favicon.ico"
-    />
 
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,700,400italic"
-      type="text/css"
-    />
-    <link rel="stylesheet" type="text/css" href="css/style.css" />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.css"
-    />
+<head>
+  <title>Highcharts Export Server</title>
+  <link rel="icon" type="image/x-icon" href="https://www.highcharts.com/demo/static/favicon.ico" />
 
-    <script
-      type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/javascript/javascript.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/css/css.min.js"
-    ></script>
-    <script type="text/javascript" src="js/main.js"></script>
-  </head>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,700,400italic"
+    type="text/css" />
+  <link rel="stylesheet" type="text/css" href="css/style.css" />
+  <link rel="stylesheet" type="text/css"
+    href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.css" />
 
-  <body>
-    <div class="page box-size">
-      <div class="panel-container main-panel box-size">
-        <div class="panel">
-          <h1>Highcharts Export Server</h1>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.js"></script>
+  <script type="text/javascript"
+    src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/javascript/javascript.min.js"></script>
+  <script type="text/javascript"
+    src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/css/css.min.js"></script>
+  <script type="text/javascript" src="js/main.js"></script>
+</head>
+
+<body>
+  <div class="page box-size">
+    <div class="panel-container main-panel box-size">
+      <div class="panel">
+        <h1>Highcharts Export Server</h1>
+
+        <p>
           This page allows you to experiment with different options for the
-          export server.
+          export server. If you use the public Export Server at
+          <a href="https://export.highcharts.com">https://export.highcharts.com</a>
+          you should read our <a href="https://www.highcharts.com/docs/export-module/privacy-disclaimer-export"
+            target="_blank">Terms of use and Fair Usage Policy.</a>
+        </p>
 
-          <label>Options</label>
-          <div class="info">Your Highcharts configuration object.</div>
-          <div class="error" id="error"></div>
-          <textarea id="options" class="codeinput box-size">
+        <label>Options</label>
+        <div class="info">Your Highcharts configuration object.</div>
+        <div class="error" id="error"></div>
+        <textarea id="options" class="codeinput box-size">
 {
     "xAxis": {
         "categories": [
@@ -77,61 +67,62 @@
 }
           </textarea>
 
-          <label>Image file format</label>
-          <select id="format" class="box-size">
-            <option>image/png</option>
-            <option>image/jpeg</option>
-            <option>image/svg+xml</option>
-            <option>application/pdf</option>
-          </select>
+        <label>Image file format</label>
+        <select id="format" class="box-size">
+          <option>image/png</option>
+          <option>image/jpeg</option>
+          <option>image/svg+xml</option>
+          <option>application/pdf</option>
+        </select>
 
-          <label>Width</label>
-          <div class="info box-size">
-            The exact pixel width of the exported image. Defaults to chart.width
-            or 600px. Maximum width is 2000px.
-          </div>
-          <input type="number" class="box-size" id="width" />
-
-          <label>Scale</label>
-          <div class="info box-size">
-            A scaling factor for a higher image resolution. Maximum scaling is
-            set to 4x. Remember that the width parameter has a higher precedence
-            over scaling.
-          </div>
-          <input type="number" id="scale" class="box-size" />
-
-          <label>Constructor</label>
-          <div class="info box-size">
-            Either a chart, stockChart, mapChart, or a ganttChart (depending on what product you use).
-          </div>
-          <select id="constr">
-            <option>chart</option>
-            <option>stockChart</option>
-            <option>mapChart</option>
-            <option>ganttChart</option>
-          </select>
+        <label>Width</label>
+        <div class="info box-size">
+          The exact pixel width of the exported image. Defaults to chart.width
+          or 600px. Maximum width is 2000px.
         </div>
-      </div>
+        <input type="number" class="box-size" id="width" />
 
-      <div class="panel-container chart-panel box-size">
-        <div class="panel" style="pointer-events: auto">
-          <h1>Result Preview</h1>
-          <div id="preview-container" class="preview-container">
-            <div class="info">Click the Preview button to see a preview.</div>
-          </div>
+        <label>Scale</label>
+        <div class="info box-size">
+          A scaling factor for a higher image resolution. Maximum scaling is
+          set to 4x. Remember that the width parameter has a higher precedence
+          over scaling.
         </div>
-      </div>
+        <input type="number" id="scale" class="box-size" />
 
-      <div class="buttons">
-        <button id="preview" class="button">PREVIEW</button>
-        <button id="download" class="button">DOWNLOAD</button>
+        <label>Constructor</label>
+        <div class="info box-size">
+          Either a chart, stockChart, mapChart, or a ganttChart (depending on what product you use).
+        </div>
+        <select id="constr">
+          <option>chart</option>
+          <option>stockChart</option>
+          <option>mapChart</option>
+          <option>ganttChart</option>
+        </select>
       </div>
     </div>
 
-    <div class="header"></div>
-  </body>
+    <div class="panel-container chart-panel box-size">
+      <div class="panel" style="pointer-events: auto">
+        <h1>Result Preview</h1>
+        <div id="preview-container" class="preview-container">
+          <div class="info">Click the Preview button to see a preview.</div>
+        </div>
+      </div>
+    </div>
 
-  <script>
-    highexp.init();
-  </script>
+    <div class="buttons">
+      <button id="preview" class="button">PREVIEW</button>
+      <button id="download" class="button">DOWNLOAD</button>
+    </div>
+  </div>
+
+  <div class="header"></div>
+</body>
+
+<script>
+  highexp.init();
+</script>
+
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,16 @@
   <link rel="stylesheet" type="text/css"
     href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.css" />
 
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/codemirror.js"
+    integrity="sha256-nmc3i0zqNwShb7mBJjCzsMqeITv9DcHvkJ9gxmfnV+8=" crossorigin="anonymous"></script>
+
   <script type="text/javascript"
-    src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/javascript/javascript.min.js"></script>
-  <script type="text/javascript"
-    src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/css/css.min.js"></script>
+    src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/javascript/javascript.min.js"
+    integrity="sha256-VCI9wgJK81jD+WoGeiVQXSS7MMWqjRbZQ446hRcLmBU=" crossorigin="anonymous"></script>
+
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.20.2/mode/css/css.min.js"
+    integrity="sha256-D5oJ11cOmRhXSYWELwG2U/XYH3YveZJr9taRYLZ2DSM=" crossorigin="anonymous"></script>
+
   <script type="text/javascript" src="js/main.js"></script>
 </head>
 


### PR DESCRIPTION
The only change in this pull request is adding the fair usage policy link. The other changes are related to prettier of the `index.html` file.

---
*Internal note*:

The updated page looks exactly the same as it used to. Only an additional sentence has been added to the description below the `<h1>`, including now the fair usage policy link (same as readme).

<img width="1277" alt="Screenshot 2024-10-08 at 06 21 10" src="https://github.com/user-attachments/assets/ed2d702b-749c-40cb-9893-5d5e07c652fd">