### PR TITLE
fix/pool-improperly-destroyed

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -230,6 +230,7 @@ export async function killPool() {
     if (!pool.destroyed) {
       await pool.destroy();
       log(4, '[browser] Destroyed the pool of resources.');
+      pool = false;
     }
   }
 


### PR DESCRIPTION
### Description of the problem
1. Called `killPool()` - it should kill the pool
2. Called `initPool()` - instead of initializing the pool, we got this:

```javascript
if (pool) {
    return log(4, '[pool] Already initialized, please kill it before creating a new one.');
 }
```

That's because `pool = true`, it was not set to `false` after destruction :) 

Reported by an ADV user on FreshDesk.