### PR TITLE
bugfix/improper-status-code

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -244,7 +244,7 @@ export async function newPage(poolResource) {
 
   // Throw an error in case of no connected browser
   if (!browser || !browser.connected) {
-    throw new ExportError(`[browser] Browser is not yet connected.`, 400);
+    throw new ExportError(`[browser] Browser is not yet connected.`, 500);
   }
 
   // Create a page

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -140,7 +140,8 @@ export const fetchAndProcessScript = async (
 
   if (shouldThrowError) {
     throw new ExportError(
-      `Could not fetch the ${script}.js. The script might not exist in the requested version (status code: ${response.statusCode}).`
+      `Could not fetch the ${script}.js. The script might not exist in the requested version (status code: ${response.statusCode}).`,
+      500
     ).setError(response);
   } else {
     log(
@@ -186,9 +187,10 @@ export const fetchScripts = async (
         port: proxyPort
       });
     } catch (error) {
-      throw new ExportError('[cache] Could not create a Proxy Agent.').setError(
-        error
-      );
+      throw new ExportError(
+        '[cache] Could not create a Proxy Agent.',
+        500
+      ).setError(error);
     }
   }
 
@@ -270,7 +272,8 @@ export const updateCache = async (
     return fetchedModules;
   } catch (error) {
     throw new ExportError(
-      '[cache] Unable to update the local Highcharts cache.'
+      '[cache] Unable to update the local Highcharts cache.',
+      500
     ).setError(error);
   }
 };

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -527,6 +527,15 @@ const exportAsString = (stringToExport, options, endCallback) => {
     // Try to parse to JSON and call the doExport function
     const chartJSON = JSON.parse(stringToExport.replaceAll(/\t|\n|\r/g, ' '));
 
+    if (!chartJSON || !(typeof chartJSON === 'object')) {
+      return endCallback(
+        new ExportError(
+          '[chart] Invalid configuration provided - the options must be an object, not a string',
+          400
+        )
+      );
+    }
+
     // If a correct JSON, do the export
     return doExport(options, chartJSON, endCallback);
   } catch (error) {

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -527,7 +527,7 @@ const exportAsString = (stringToExport, options, endCallback) => {
     // Try to parse to JSON and call the doExport function
     const chartJSON = JSON.parse(stringToExport.replaceAll(/\t|\n|\r/g, ' '));
 
-    if (!chartJSON || !(typeof chartJSON === 'object')) {
+    if (!chartJSON || typeof chartJSON !== 'object') {
       return endCallback(
         new ExportError(
           '[chart] Invalid configuration provided - the options must be an object, not a string',

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -114,7 +114,7 @@ export const startExport = async (settings, endCallback) => {
           );
     } catch (error) {
       return endCallback(
-        new ExportError('[chart] Error loading raw input.').setError(error)
+        new ExportError('[chart] Error loading raw input.', 400).setError(error)
       );
     }
   }


### PR DESCRIPTION
When calling `exportAsString`, sometimes the `chartJSON` was not an object but a string, which caused multiple errors further down in the application, causing a "500 internal server error" instead of 400.