### PR TITLE
Add next(error) in returnErrorMiddleware

### DIFF
--- a/lib/server/error.js
+++ b/lib/server/error.js
@@ -37,6 +37,8 @@ const returnErrorMiddleware = (error, req, res, next) => {
 
   // Set and return response
   res.status(statusCode).json({ statusCode, message, stack });
+
+  next(error);
 };
 
 export default (app) => {


### PR DESCRIPTION
This makes it possible to add other custom error handlers. We use this to add Appsignal error handling (https://www.appsignal.com/nodejs).